### PR TITLE
Don’t ever require a match

### DIFF
--- a/esh-autosuggest.el
+++ b/esh-autosuggest.el
@@ -117,7 +117,8 @@ respectively."
     (interactive (company-begin-backend 'esh-autosuggest))
     (prefix (and (eq major-mode 'eshell-mode)
                  (esh-autosuggest--prefix)))
-    (candidates (esh-autosuggest-candidates arg))))
+    (candidates (esh-autosuggest-candidates arg))
+    (require-match 'never)))
 
 (define-minor-mode esh-autosuggest-mode
   "Enable fish-like autosuggestions in eshell.


### PR DESCRIPTION
Hey,

Thanks for this nice package :)

The current behaviour locks the user in to a known completion whenever a partial completion is made.

So if I call `esh-autosuggest-complete-word` to partially complete a suggestion, I can't type in anything other than the available options. By setting the `require-match` to never, you can partially complete and always still keep typing when you need to diverge from the suggestion.