### PR TITLE
esh-autosuggest--prefix: Fix input-start 

### DIFF
--- a/esh-autosuggest.el
+++ b/esh-autosuggest.el
@@ -34,6 +34,8 @@
 
 (require 'company)
 (require 'cl-lib)
+(eval-when-compile (require 'eshell))
+(require 'em-prompt)
 
 (defgroup esh-autosuggest nil
   "Fish-like autosuggestions for eshell."
@@ -107,7 +109,7 @@ respectively."
       'stop)))
 
 ;;;###autoload
-(defun esh-autosuggest (command &optional arg &rest ignored)
+(defun esh-autosuggest (command &optional arg &rest _ignored)
   "`company-mode' backend to provide eshell history suggestion."
   (interactive (list 'interactive))
   (cl-case command

--- a/esh-autosuggest.el
+++ b/esh-autosuggest.el
@@ -93,13 +93,10 @@ respectively."
 
 (defun esh-autosuggest--prefix ()
   "Get current eshell input."
-  (let* ((input-start (progn
-                        (save-excursion
-                          (beginning-of-line)
-                          (while (not (looking-at-p eshell-prompt-regexp))
-                            (forward-line -1))
-                          (re-search-forward eshell-prompt-regexp nil 'noerror)
-                          (eshell-bol))))
+  (let* ((input-start (save-excursion
+                        (eshell-previous-prompt 1)
+                        (eshell-next-prompt 1)
+                        (point)))
          (prefix
           (string-trim-left
            (buffer-substring-no-properties


### PR DESCRIPTION
This affects Emacs 30 right now (I think, anyways), but the fix should be plenty backwards compatible

## Commit Summary

### [esh-autosuggest--prefix: Fix input-start](https://github.com/dieggsy/esh-autosuggest/commit/8335a253d319796ab8972f13867f848a5fb6def9)

In Emacs 30+, `eshell-bol` is merely an alias for `beginning-of-line`,
not returning the point any longer.  This result in `input-start` always
returning nil instead of the correct position of the point.  Further,
the implementation misbehaves when there is no previous prompt at all,
hanging Emacs.  There are built in ways to query the previous and next
prompt in order to get a sensible starting position, so use these
instead.

### [Pacify the byte compiler](https://github.com/dieggsy/esh-autosuggest/commit/beafdcc67758077f22cec171df84bdbcbd31613e)